### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java
@@ -7,12 +7,16 @@
 package com.github.kyriosdata.exemplo.application.console;
 
 import com.github.kyriosdata.exemplo.domain.Calendario;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Programa que exibe o dia da semana para o dia em que é executado.
  *
  */
 public final class ProgramaCalendario {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProgramaCalendario.class);
 
     /**
      * Restringe criação de instância.
@@ -27,7 +31,7 @@ public final class ProgramaCalendario {
      * @param args Ignorados.
      */
     public static void main(final String[] args) {
-        System.out.println(Calendario.diaDaSemanaParaHoje());
+        logger.info(Calendario.diaDaSemanaParaHoje());
     }
 
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 0e55a6752ab52d64537b6eb0bc7b9e0d1efbb5ff

**Descrição:** Neste commit, houve uma atualização no arquivo `ProgramaCalendario.java` no qual foi adicionado a utilização do `Logger` para exibir o dia da semana, ao invés da abordagem anterior que utilizava `System.out.println`.

**Sumário:** 
- Arquivo: `src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java` (alterado)
- Foi adicionado o import das classes `Logger` e `LoggerFactory` do pacote `org.slf4j`.
- Foi criado um objeto `Logger` para a classe `ProgramaCalendario`.
- A linha que usava `System.out.println` para imprimir o dia da semana foi substituída pelo `logger.info`.

**Recomendações:** Recomendo que o revisor confirme se o uso do `Logger` está conforme o padrão de codificação da equipe e se o nível de log `info` é o mais adequado para essa informação. Além disso, aconselho a executar o programa para garantir que o log está sendo exibido corretamente.

**Explicação de Vulnerabilidades:** Não foram encontradas vulnerabilidades neste commit.