### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java
@@ -35,6 +35,10 @@ public class DiaDaSemanaController {
     public DiaDaSemana diaDaSemana(@RequestParam(value= "data", defaultValue =
             "não fornecida") String data) {
 
+        if(data == null || data.isEmpty()) { // Incluido por GFT AI Impact Bot
+            throw new IllegalArgumentException("Data não pode ser nula ou vazia"); // Incluido por GFT AI Impact Bot
+        }
+
         LocalDate localDate = localDateFromString(data);
 
         // Se localDate não é fornecida, ou é inválida, use o dia corrente.


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 8fc59869c6eb236aeca9f478c77d8d5e194a77f6

**Descrição:** Este pull request modifica a classe `DiaDaSemanaController` no pacote `src/main/java/com/github/kyriosdata/exemplo/application/api/`. O objetivo principal da modificação é adicionar uma verificação para o parâmetro `data` na função `diaDaSemana`, para garantir que ele não seja nulo ou vazio.

**Sumario:** 
- `src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java` (modificado): 
   - A função `diaDaSemana` agora lança uma exceção IllegalArgumentException se o valor de `data` for nulo ou vazio. 
   - Uma nova condição if foi adicionada para verificar se `data` é nulo ou vazio.

**Recomendações:** É recomendável testar essa alteração com diferentes valores para `data`, incluindo valores nulos e vazios, bem como valores não nulos e não vazios, para garantir que a exceção seja lançada corretamente e que a função funcione como esperado com valores válidos.

Por favor, revise e aprove se tudo estiver conforme esperado.