### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/domain/Calendario.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/domain/Calendario.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/domain/Calendario.java
@@ -48,13 +48,6 @@ public final class Calendario {
     public static final int CALENDARIO_GREGORIANO = 1753;
 
     /**
-     * Não é esperada criação de instâncias desta classe.
-     */
-    protected Calendario() {
-        // Apenas para agradar análise de cobertura
-    }
-
-    /**
      * Nomes dos dias da semana, iniciado por "segunda-feira" (índice 0),
      * seguido de terça-feira (índice 1) e assim sucessivamente, até
      * "domingo" (índice 6).
@@ -118,6 +111,9 @@ public final class Calendario {
         int ano = hoje.getYear();
         int diaDaSemana = diaDaSemana(dia, mes, ano);
 
-        return String.format("Hoje é %s\n", semana[diaDaSemana]);
+        StringBuilder sb = new StringBuilder(); // Alterado por GFT AI Impact Bot
+        sb.append("Hoje é ").append(semana[diaDaSemana]).append("\n"); // Alterado por GFT AI Impact Bot
+
+        return sb.toString(); // Alterado por GFT AI Impact Bot
     }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o bdbac308fa09b4e47b5bf8393ecfd9f7b4ca9a1c
                                                
**Descrição:** O Pull Request 30 intitulado '[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/domain/Calendario.java' apresenta a alteração do método responsável por retornar o dia da semana atual e a remoção do construtor protegido da classe Calendario.

**Sumario:**

- **src/main/java/com/github/kyriosdata/exemplo/domain/Calendario.java (modificado)** - O construtor protegido da classe Calendario foi removido. O método 'diaDaSemanaParaHoje' foi alterado: ao invés de usar o método 'String.format' para formatar a string de retorno, agora é utilizado um 'StringBuilder' para construir a string.

**Recomendações:** 

- **Testes:** Recomendo que seja feito um teste para o método 'diaDaSemanaParaHoje', verificando se o retorno é o esperado após a alteração.
- **Código:** Recomendo a revisão da remoção do construtor da classe Calendario, pois essa remoção pode ter impacto em outros códigos que utilizam essa classe.

**Explicação de Vulnerabilidades:** Não foram encontradas vulnerabilidades atuais ou que estão sendo corrigidas neste Pull Request.