### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java
@@ -35,6 +35,10 @@ public class DiaDaSemanaController {
     public DiaDaSemana diaDaSemana(@RequestParam(value= "data", defaultValue =
             "não fornecida") String data) {
 
+        if(data == null || data.isEmpty()) { // Incluido por GFT AI Impact Bot
+            throw new IllegalArgumentException("Data não pode ser nula ou vazia"); // Incluido por GFT AI Impact Bot
+        }
+
         LocalDate localDate = localDateFromString(data);
 
         // Se localDate não é fornecida, ou é inválida, use o dia corrente.


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o bd4effeda6d1f51fb2e36f89705f3bb1d7fc92d6
**Descrição:** Uma validação foi adicionada no método diaDaSemana para evitar que a data seja nula ou vazia. Se a data for nula ou vazia, uma exceção será lançada.

**Sumário:** 
- src/main/java/com/github/kyriosdata/exemplo/application/api/DiaDaSemanaController.java (alterado) - Adicionado uma verificação de nulidade e vazio na data fornecida. Se a data for nula ou vazia, uma exceção IllegalArgumentException é lançada.

**Recomendações:** 
- Verifique se a nova validação está funcionando conforme o esperado e se a exceção é lançada corretamente quando a data é nula ou vazia.
- Verifique se a mensagem de erro é clara e compreensível.
- Certifique-se de que a validação não quebra nenhuma outra funcionalidade.
- Sugiro adicionar testes unitários para esta nova validação.
