### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/domain/DiaDaSemana.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/domain/DiaDaSemana.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/domain/DiaDaSemana.java
@@ -24,6 +24,9 @@ public class DiaDaSemana {
      * @param diaDaSemana Dia da semana.
      */
     public DiaDaSemana(LocalDate data, String diaDaSemana) {
+        if(data == null || diaDaSemana == null || diaDaSemana.isEmpty()) { // Incluido por GFT AI Impact Bot
+            throw new IllegalArgumentException("Data e dia da semana não podem ser nulos ou vazios"); // Incluido por GFT AI Impact Bot
+        }
         this.data = data;
         this.diaDaSemana = diaDaSemana;
     }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 362e59bd5e10810907c867d7bc9562a30ed40214
                                                
**Descrição:** As alterações feitas neste pull request estão relacionadas à validação de entrada no construtor da classe DiaDaSemana. Agora, o código verifica se a data e o dia da semana passados como argumentos não são nulos ou vazios.

**Sumario:** 
- **src/main/java/com/github/kyriosdata/exemplo/domain/DiaDaSemana.java (modificado)**: Adicionada uma validação no construtor da classe para garantir que a data e o dia da semana não sejam nulos ou vazios. Se essa condição não for atendida, uma exceção IllegalArgumentException é lançada com a mensagem: "Data e dia da semana não podem ser nulos ou vazios".

**Recomendações:** Para o revisor, é importante verificar se essa validação não quebra nenhuma funcionalidade existente e se a exceção é tratada corretamente em todas as partes do código que utilizam a classe DiaDaSemana. Sugiro realizar testes unitários para garantir que tudo esteja funcionando corretamente.
