### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java
@@ -27,7 +27,13 @@ public final class ProgramaCalendario {
      * @param args Ignorados.
      */
     public static void main(final String[] args) {
-        System.out.println(Calendario.diaDaSemanaParaHoje());
+        // Alterado por GFT AI Impact Bot: Adicionado verificação de nulo para evitar NullPointerException
+        String diaDaSemana = Calendario.diaDaSemanaParaHoje();
+        if (diaDaSemana != null) {
+            System.out.println(diaDaSemana);
+        } else {
+            System.out.println("Erro: Não foi possível obter o dia da semana");
+        }
     }
 
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 94bfad12974cc1bc04fa1649f53bf75320073026

**Descrição:** No arquivo `ProgramaCalendario.java`, foi adicionada uma verificação de nulo para a variável `diaDaSemana`, que recebe o retorno do método `Calendario.diaDaSemanaParaHoje()`. Isso foi feito para evitar a possibilidade de um `NullPointerException`. Se `diaDaSemana` for nulo, será exibida a mensagem "Erro: Não foi possível obter o dia da semana".

**Sumário:** 
- `src/main/java/com/github/kyriosdata/exemplo/application/console/ProgramaCalendario.java` (modificado) - Adicionada verificação de nulo para a variável `diaDaSemana` para evitar `NullPointerException`.

**Recomendações:** 
- Recomendo que o revisor teste este código em um ambiente onde o método `Calendario.diaDaSemanaParaHoje()` possa retornar nulo para garantir que a nova mensagem de erro seja exibida corretamente.
- Verifique se a nova mensagem de erro é apropriada para o contexto do aplicativo.
- Certifique-se de que a adição desta verificação de nulo não afeta outras partes do código que dependem do método `Calendario.diaDaSemanaParaHoje()`.