### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/github/kyriosdata/exemplo/application/api/Application.java

### DIFF
--- a/src/main/java/com/github/kyriosdata/exemplo/application/api/Application.java
+++ b/src/main/java/com/github/kyriosdata/exemplo/application/api/Application.java
@@ -22,6 +22,10 @@ public class Application {
      * @param args Ignorados. Não são usados.
      */
     public static void main(String[] args) {
+        // Incluido por GFT AI Impact Bot: Verificação de nulidade para evitar NullPointerException
+        if (args == null) {
+            throw new IllegalArgumentException("args não pode ser nulo");
+        }
         SpringApplication.run(Application.class, args);
     }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o a01fa5f4fd3dbbaffed9345f44ce01520b680bed

**Descrição:** 
Uma verificação de nulidade foi incluída no método `main` da classe `Application.java`. Essa verificação tem o objetivo de evitar que um `NullPointerException` seja lançado caso o argumento `args` seja nulo.

**Sumario:**
- src/main/java/com/github/kyriosdata/exemplo/application/api/Application.java (modificado) - Foi adicionada uma verificação de nulidade para o argumento `args` no método `main`. Se `args` for nulo, uma `IllegalArgumentException` será lançada.

**Recomendações:** 
- Verifique se a verificação de nulidade está corretamente implementada e se a mensagem de exceção é clara o suficiente para o usuário entender o erro.
- Recomenda-se testar o método `main` com `args` nulo para garantir que a exceção é lançada como esperado.
- Também é importante verificar se a exceção não afeta o fluxo normal do programa quando `args` não é nulo.

Seu report será salvo em Markdown, então deixe sua resposta no formato Markdown.